### PR TITLE
Remove fixincludes patch applied to GCC on AT 13

### DIFF
--- a/configs/13.0/packages/gcc/sources
+++ b/configs/13.0/packages/gcc/sources
@@ -64,11 +64,6 @@ atsrc_get_patches ()
 		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/master/GCC%20libstdc%2B%2B%20PowerPC%20Patches/9/0001-libstdc-Prevent-LD_LIBRARY_PATH-from-leaking-to-msgf.patch' \
 		9cba9a9b94ca9c1b8958c0d722a9c06b || return ${?}
 
-	# Skip machine_name fix on GCC fixincludes step.
-	at_get_patch \
-		'https://raw.githubusercontent.com/powertechpreview/powertechpreview/fb462137df68be149d94b1cbde1dd141f32361fa/GCC%20PowerPC%20Backport/9/0001-Skip-machine_name-fix-for-powerpc-on-fixincludes-ste.patch' \
-		7b6e39981c83b5f4634693034c7ffbc7 || return ${?}
-
 	return 0
 }
 
@@ -80,9 +75,5 @@ atsrc_apply_patches ()
 
 	patch -p1 \
 	      < 0001-libstdc-Prevent-LD_LIBRARY_PATH-from-leaking-to-msgf.patch \
-		|| return ${?}
-
-	patch -p1 \
-	      < 0001-Skip-machine_name-fix-for-powerpc-on-fixincludes-ste.patch \
 		|| return ${?}
 }


### PR DESCRIPTION
Hi @er-1, I'm opening this PR here so the commit gets added to advancetoolchain/advance-toolchain#1420.

This fixes the build issues seen there.

--

The patch to ignore machine_name fixincludes fix for Power builds
has been backported to GCC 9 upstream branch (ref 53280279777),
so there is no need to apply it anymore here.

Signed-off-by: Matheus Castanho <msc@linux.ibm.com>